### PR TITLE
feat: Include not-found films in API response

### DIFF
--- a/routes/films.js
+++ b/routes/films.js
@@ -119,6 +119,7 @@ router.get('/list',  async function(req, res) {
   }
 
   var _NbFilms=0;
+  var filmTitlesFromIA = null;
 
   if(!_skip) {
     _skip=0;
@@ -236,7 +237,7 @@ if(!_sortsens) {
                   }
                 }
             */
-
+            filmTitlesFromIA = srequete.map(item => item.title);
             srequete = convertToMongoInQueryTitle(srequete);
             console.log('srequete convertie="'+iaChoice+'"',srequete );    
         }
@@ -299,6 +300,15 @@ if(!_sortsens) {
       });
 
       collection.find(objrequete,optionBD,function(e,docs){
+        if (filmTitlesFromIA) {
+          const foundTitles = docs.map(doc => doc.original_title);
+          const missingTitles = filmTitlesFromIA.filter(title => !foundTitles.includes(title));
+          const missingFilms = missingTitles.map(title => ({
+            original_title: title,
+            status: 'not_found'
+          }));
+          docs = docs.concat(missingFilms);
+        }
         //Add header info
         res.append('NbFilms', _NbFilms);
         res.json(docs);


### PR DESCRIPTION
When the API is called with `iaChoice=RECHERCHE_IA2`, the response now includes films that were part of the AI's suggestions but were not found in the database.

- A new variable, `filmTitlesFromIA`, is populated with the list of film titles from the AI service before the database query is constructed.
- After the database query, the list of found films is compared against `filmTitlesFromIA`.
- Any films from the AI's list that are not found in the database are added to the response with a `status` of `not_found`.
- The combined list of found and not-found films is returned in the JSON response.

This allows the frontend to display all the films suggested by the AI, with a clear indication of which ones are not in the local database.